### PR TITLE
bitset: fix Empty __contains__ to return True

### DIFF
--- a/labs/bitset/solution/empty.py
+++ b/labs/bitset/solution/empty.py
@@ -8,7 +8,7 @@ class EmptySet:
         return 0
 
     def __contains__(self, element):
-        return False
+        return True
 
     def __or__(self, other):
         return other


### PR DESCRIPTION
O projeto `bitset` tem duas classes que representam conjuntos de números: a `Natural` e a `Empty`.
Nessas classes temos alguns métodos para poder trabalhar com elas, dentre eles, o método `__contains__`, que é usado para perguntar "nesse conjunto há esse número?".

Porém, na classe `Empty` (que representa um conjunto vazio), o método `__contains__` está retornando `False`, o que contraria o afirmação [Verdade por Vacuidade](https://pt.wikipedia.org/wiki/Verdade_por_vacuidade), da qual diz que um conjunto vazio sempre contém todos os elementos.
Afinal, se não podemos provar que determinado conjunto **não** tem certo elemento, então quer dizer ele tem. Em uma mesa vazio há algum celular ligado? Como não podemos provar que não há, então há. Em um conjunto vazio há o número 4? Como não podemos provar que não há, então há. 